### PR TITLE
Bumped Halide version, added Python bindings

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,6 +9,14 @@ fi
 make -j${NUM_CPUS}
 make install PREFIX=$PREFIX
 
+(
+    cd python_bindings
+    make -j${NUM_CPUS}
+    cp build/halide.so ${SP_DIR}
+    mkdir -p $PREFIX/share/halide/tutorial/python
+    cp tutorial/*.py $PREFIX/share/halide/tutorial/python
+)
+
 if [[ $(uname) == "Darwin" ]]; then
     # set the dll id on macOS
     LIBHALIDE="$PREFIX/lib/libHalide.so"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "halide" %}
-{% set version = "2016.10.25" %}
-{% set sha256 = "2d4beac52b8c710e3001b61679eabe6d49bc5bf17abf9b284dbce81d8f5b762b" %}
-{% set build = 1 %}
+{% set version = "2017.05.03" %}
+{% set sha256 = "22db6c51ad19d5621ebbada18ab2c6f4da30d6f71c3904aefc302ddadada48f9" %}
+{% set build = 0 %}
 
 package:
   name: {{ name }}
@@ -13,6 +13,7 @@ source:
   sha256: {{ sha256 }}
   patches:
     - ldflags.patch
+    - python_bindings_makefile.patch
 
 build:
   number: {{ build }}
@@ -20,16 +21,22 @@ build:
 
 requirements:
   build:
+    - python
     - toolchain
     - clangdev
     - llvmdev
+    - boost
     - zlib 1.2.*
   run:
+    - python
+    - boost
     - zlib 1.2.*
 
 test:
   requires:
     - toolchain
+  imports:
+    - halide
 
 about:
   home: http://halide-lang.org

--- a/recipe/python_bindings_makefile.patch
+++ b/recipe/python_bindings_makefile.patch
@@ -1,0 +1,32 @@
+--- a/python_bindings/Makefile
++++ b/python_bindings/Makefile
+@@ -4,21 +4,23 @@
+ ROOT_DIR = $(strip $(shell dirname $(THIS_MAKEFILE)))
+ HALIDE_DIR ?= ..
+ 
++PYTHON_MAJOR=$(shell python --version 2>&1 | cut -d' ' -f2 | cut -b1)
++PYTHON_CONFIG=python$(PYTHON_MAJOR)-config
++
+ ifeq ($(UNAME), Linux)
+ # Disable some warnings that are pervasive in Boost
+-CCFLAGS=$(shell python3-config --cflags) -I $(HALIDE_DIR)/include -std=c++11 -fPIC -Wno-unused-local-typedef -Wno-shorten-64-to-32
+-PYTHON_VER=$(shell python3 --version | cut -d' ' -f2 | cut -b1,3)
+-LDFLAGS=$(shell python3-config --ldflags) -lboost_python-py$(PYTHON_VER) -lz
++CCFLAGS=$(shell $(PYTHON_CONFIG) --cflags) -I $(HALIDE_DIR)/include -std=c++11 -fPIC -Wno-unused-local-typedef -Wno-shorten-64-to-32
++LDFLAGS=$(shell $(PYTHON_CONFIG) --ldflags) -lboost_python$(PYTHON_MAJOR) -Wl,--no-as-needed -lz
+ endif
+ 
+ ifeq ($(UNAME), Darwin)
+ # The /opt includes are in case this is a macports install of python and boost python
+ # Disable some warnings that are pervasive in Boost
+-CCFLAGS=$(shell python-config --cflags) -I $(HALIDE_DIR)/include -I /opt/local/include -std=c++11 -Wno-unused-local-typedef -Wno-shorten-64-to-32
+-LDFLAGS=$(shell python-config --ldflags) -L /opt/local/lib -lboost_python3-mt -lz
++CCFLAGS=$(shell $(PYTHON_CONFIG) --cflags) -I $(HALIDE_DIR)/include -I /opt/local/include -std=c++11 -Wno-unused-local-typedef -Wno-shorten-64-to-32
++LDFLAGS=$(shell $(PYTHON_CONFIG) --ldflags) -L /opt/local/lib -lboost_python$(PYTHON_MAJOR) -Wl,--no-as-needed -lz
+ endif
+ 
+-NUMPY_PATH=$(shell python3 -c "import numpy; print(numpy.__path__[0] + '/core/include')")
++NUMPY_PATH=$(shell python -c "import numpy; print(numpy.__path__[0] + '/core/include')")
+ 
+ PY_SRCS=$(shell ls $(ROOT_DIR)/python/*.cpp)
+ PY_OBJS=$(PY_SRCS:$(ROOT_DIR)/python/%.cpp=build/py_%.o)

--- a/recipe/python_bindings_makefile.patch
+++ b/recipe/python_bindings_makefile.patch
@@ -12,7 +12,7 @@
 -CCFLAGS=$(shell python3-config --cflags) -I $(HALIDE_DIR)/include -std=c++11 -fPIC -Wno-unused-local-typedef -Wno-shorten-64-to-32
 -PYTHON_VER=$(shell python3 --version | cut -d' ' -f2 | cut -b1,3)
 -LDFLAGS=$(shell python3-config --ldflags) -lboost_python-py$(PYTHON_VER) -lz
-+CCFLAGS=$(shell $(PYTHON_CONFIG) --cflags) -I $(HALIDE_DIR)/include -std=c++11 -fPIC -Wno-unused-local-typedef -Wno-shorten-64-to-32
++CCFLAGS=$(shell $(PYTHON_CONFIG) --cflags) -I $(HALIDE_DIR)/include -I $(PREFIX)/include -std=c++11 -fPIC -Wno-unused-local-typedef -Wno-shorten-64-to-32
 +LDFLAGS=$(shell $(PYTHON_CONFIG) --ldflags) -lboost_python$(PYTHON_MAJOR) -Wl,--no-as-needed -lz
  endif
  
@@ -21,7 +21,7 @@
  # Disable some warnings that are pervasive in Boost
 -CCFLAGS=$(shell python-config --cflags) -I $(HALIDE_DIR)/include -I /opt/local/include -std=c++11 -Wno-unused-local-typedef -Wno-shorten-64-to-32
 -LDFLAGS=$(shell python-config --ldflags) -L /opt/local/lib -lboost_python3-mt -lz
-+CCFLAGS=$(shell $(PYTHON_CONFIG) --cflags) -I $(HALIDE_DIR)/include -I /opt/local/include -std=c++11 -Wno-unused-local-typedef -Wno-shorten-64-to-32
++CCFLAGS=$(shell $(PYTHON_CONFIG) --cflags) -I $(HALIDE_DIR)/include -I $(PREFIX)/include -I /opt/local/include -std=c++11 -Wno-unused-local-typedef -Wno-shorten-64-to-32
 +LDFLAGS=$(shell $(PYTHON_CONFIG) --ldflags) -L /opt/local/lib -lboost_python$(PYTHON_MAJOR) -Wl,--no-as-needed -lz
  endif
  


### PR DESCRIPTION
Given conda originating from the Python ecosystem I was somewhat puzzled to see the Python bindings of Halide not being built.

I've bumped Halide to the current version, and added the necessary changes to build and install Halide's Python bindings.

I've only tested it on Linux (w/Python 3); I'll check what Travis reports for macOS or Python 2.

Best regards, Christian